### PR TITLE
[CE-192] Add aditional check to set_post_contents

### DIFF
--- a/WP_Router_Page.class.php
+++ b/WP_Router_Page.class.php
@@ -128,11 +128,12 @@ class WP_Router_Page extends WP_Router_Utility {
 	 * @param object $post
 	 * @return void
 	 */
-	public function set_post_contents( $post ) {
-		global $pages;
-		$pages = array($this->contents);
-		// TODO: add a facility for multi-page documents?
-	}
+    public function set_post_contents( $post ) {
+        if ( $post->post_type == WP_Router_Page::POST_TYPE ) {
+            global $pages;
+            $pages = array( $this->contents );
+        }
+    }
 
 	/**
 	 * Set the title for the placeholder page

--- a/WP_Router_Page.class.php
+++ b/WP_Router_Page.class.php
@@ -130,9 +130,9 @@ class WP_Router_Page extends WP_Router_Utility {
      * @return void
      */
     public function set_post_contents( $post ) {
-        if ( $post->post_type == WP_Router_Page::POST_TYPE ) {
+        if ( WP_Router_Page::POST_TYPE == $post->post_type ) {
             global $pages;
-            $pages = array( $this->contents );
+            $pages = [ $this->contents ];
         }
     }
 

--- a/WP_Router_Page.class.php
+++ b/WP_Router_Page.class.php
@@ -122,20 +122,20 @@ class WP_Router_Page extends WP_Router_Utility {
 		}
 	}
 
-    /**
-     * Override the global $pages array to yield our content
-     *
-     * @param WP_Post $post WordPress Post object.
-     *
-     * @return void
-     */
-    public function set_post_contents( $post ) {
-        if ( WP_Router_Page::POST_TYPE !== $post->post_type ) {
-            return;
-        }
-        global $pages;
-        $pages = [ $this->contents ];
-    }
+	/**
+	 * Override the global $pages array to yield our content
+	 *
+	 * @param WP_Post $post WordPress Post object.
+	 *
+	 * @return void
+	 */
+	public function set_post_contents( $post ) {
+		if ( WP_Router_Page::POST_TYPE !== $post->post_type ) {
+			return;
+		}
+		global $pages;
+		$pages = [ $this->contents ];
+	}
 
 	/**
 	 * Set the title for the placeholder page

--- a/WP_Router_Page.class.php
+++ b/WP_Router_Page.class.php
@@ -125,15 +125,16 @@ class WP_Router_Page extends WP_Router_Utility {
     /**
      * Override the global $pages array to yield our content
      *
-     * @param object $post
+     * @param WP_Post $post WordPress Post object.
      *
      * @return void
      */
     public function set_post_contents( $post ) {
-        if ( WP_Router_Page::POST_TYPE == $post->post_type ) {
-            global $pages;
-            $pages = [ $this->contents ];
+        if ( WP_Router_Page::POST_TYPE !== $post->post_type ) {
+            return;
         }
+        global $pages;
+        $pages = [ $this->contents ];
     }
 
 	/**

--- a/WP_Router_Page.class.php
+++ b/WP_Router_Page.class.php
@@ -122,12 +122,13 @@ class WP_Router_Page extends WP_Router_Utility {
 		}
 	}
 
-	/**
-	 * Override the global $pages array to yield our content
-	 *
-	 * @param object $post
-	 * @return void
-	 */
+    /**
+     * Override the global $pages array to yield our content
+     *
+     * @param object $post
+     *
+     * @return void
+     */
     public function set_post_contents( $post ) {
         if ( $post->post_type == WP_Router_Page::POST_TYPE ) {
             global $pages;

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "jbrinley/wp-router",
+	"name": "the-events-calendar/wp-router",
 	"description": "Provides a simple API for mapping requests to callback functions.",
 	"type": "wordpress-plugin",
 	"authors": [

--- a/readme.txt
+++ b/readme.txt
@@ -142,6 +142,10 @@ Creating or changing routes should always occur in the context of the `wp_router
 
 == Changelog ==
 
+= TBD =
+
+* Fix - Added an additional check for `set_post_contents` so that it only runs on posts that are created via WP-Router.
+
 = 0.6 =
 
 * Make magic methods public to avoid fatal with PHP 7.3

--- a/readme.txt
+++ b/readme.txt
@@ -144,7 +144,7 @@ Creating or changing routes should always occur in the context of the `wp_router
 
 = TBD =
 
-* Fix - Added an additional check for `set_post_contents` so that it only runs on posts that are created via WP-Router.
+* Fix - Added an additional check for `set_post_contents` so that it only runs on posts that are created via WP-Router. [CE-192]
 
 = 0.6 =
 


### PR DESCRIPTION
When using themes like Divi the content is being outputted multiple times. However, WP_Router does not take into account if it's a WP_Router page. This change adds an extra check to make sure that it only replaces WP_Router content.

Since this is a fork of the original WP-Router, I'm not sure if anything else must be done to get it "release" ready. I updated the readme, any suggestions would be helpful.

[artifact-CE-192.webm](https://github.com/the-events-calendar/WP-Router/assets/12241059/a3df933a-3ee1-4b3e-b278-3245ee50049a)
