### PR TITLE
Update WP_Router_Sample.class.php

### DIFF
--- a/WP_Router_Sample.class.php
+++ b/WP_Router_Sample.class.php
@@ -7,7 +7,7 @@
  
 class WP_Router_Sample {
 	public static function init() {
-		add_action('wp_router_generate_routes', array(get_class(), 'generate_routes'), 10, 1);
+		add_action('wp_router_generate_routes', array(get_called_class(), 'generate_routes'), 10, 1);
 	}
 
 	public static function generate_routes( WP_Router $router ) {


### PR DESCRIPTION
Removed the deprecated use of the function get_class() without input. Introduced the new function get_called_class() which returns the name of the class a static method was called in.